### PR TITLE
Allow an optional presenter pdf file for notes

### DIFF
--- a/src/pdf_presenter_console.vala
+++ b/src/pdf_presenter_console.vala
@@ -157,7 +157,7 @@ namespace org.westhoffswelt.pdfpresenter {
             
             string presenter_pdf_file = args[1];
             // Optional notes pdf file given, show in presenter
-            if( args.length == 3 ) {
+            if( args.length >= 3 ) {
 	            presenter_pdf_file = args[2];
         	}
 


### PR DESCRIPTION
Makes it possible to load a different PDF file to the presenter
so one file is for the presentation slides and the other is for
the slides with notes.

See [this blog post](http://coding-journal.com/notes-with-pdf-presenter-console-and-latex-beamer/) for details.
