### PR TITLE
Add an option to log slide transition timestamps to a file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,7 @@ your likings::
       -s, --switch-screens          Switch the presentation and the presenter screen.
       -c, --disable-cache           Disable caching and pre-rendering of slides to save memory at the cost of speed.
       -z, --disable-compression     Disable the compression of slide images to trade memory consumption for speed. (Avg. factor 30)
+      -f, --log-transitions=FILE    Log slide transition times to the specified file.
 
 
 Caching / Prerendering

--- a/src/classes/options.vala
+++ b/src/classes/options.vala
@@ -67,5 +67,10 @@ namespace org.westhoffswelt.pdfpresenter {
          * this time.
          */
         public static string? start_time = null;
+
+        /**
+         * Log file for slide transition times.
+         */
+        public static string? log_file = null;
     }
 }

--- a/src/classes/window/presenter.vala
+++ b/src/classes/window/presenter.vala
@@ -110,6 +110,13 @@ namespace org.westhoffswelt.pdfpresenter.Window {
                 out current_scale_rect
             );
 
+            if (Options.log_file != null) {
+                var log = FileStream.open(Options.log_file, "w");
+                this.current_view.entering_slide.connect( (slide_number) => {
+                    log.printf("%s %u\n", new DateTime.now_local().format("%s.%N"), slide_number);
+                } );
+            }
+
             // Position it in the top left corner.
             // The scale rect information is used to center the image inside
             // its area.

--- a/src/pdf_presenter_console.vala
+++ b/src/pdf_presenter_console.vala
@@ -68,6 +68,7 @@ namespace org.westhoffswelt.pdfpresenter {
             { "switch-screens", 's', 0, 0, ref Options.display_switch, "Switch the presentation and the presenter screen.", null },
             { "disable-cache", 'c', 0, 0, ref Options.disable_caching, "Disable caching and pre-rendering of slides to save memory at the cost of speed.", null },
             { "disable-compression", 'z', 0, 0, ref Options.disable_cache_compression, "Disable the compression of slide images to trade memory consumption for speed. (Avg. factor 30)", null },
+            { "log-transitions", 'f', 0, OptionArg.STRING, ref Options.log_file, "Log slide transition times to the specified file.", "FILE" },
             { null }
         };
 


### PR DESCRIPTION
This log makes it possible to sync the slide transitions with an audio recording.  I plan to use this when defending my dissertation next week.
